### PR TITLE
Make column headers more consistent

### DIFF
--- a/2004/20041102__ok__general__corp__commissioner__county.csv
+++ b/2004/20041102__ok__general__corp__commissioner__county.csv
@@ -1,4 +1,4 @@
-County,Office,District,Party,Candidate,Votes
+county,office,district,party,candidate,votes
 ADAIR,Corporation Commissioner,,(D),John Wylie,"2,999"
 ADAIR,Corporation Commissioner,,(R),Denise Bode,"3,855"
 ALFALFA,Corporation Commissioner,,(D),John Wylie,602

--- a/2004/20041102__ok__general__president.csv
+++ b/2004/20041102__ok__general__president.csv
@@ -1,4 +1,4 @@
-County,Candidate,Party,Votes
+county,candidate,party,votes
 ADAIR,George W. Bush,REP,"4,971"
 ADAIR,John F. Kerry,DEM,"2,562"
 ALFALFA,George W. Bush,REP,"2,201"

--- a/2004/20041102__ok__general__state_house__county.csv
+++ b/2004/20041102__ok__general__state_house__county.csv
@@ -1,4 +1,4 @@
-County,Office,District,Party,Candidate,Votes
+county,office,district,party,candidate,votes
 DELAWARE,State Senate,5,(D),LeROY HENDREN,"4,889"
 DELAWARE,State Senate,5,(R),DOUG COX,"7,304"
 MAYES,State Senate,5,(D),LeROY HENDREN,"1,556"

--- a/2004/20041102__ok__general__state_senate__county.csv
+++ b/2004/20041102__ok__general__state_senate__county.csv
@@ -1,4 +1,4 @@
-County,Office,District,Party,Candidate,Votes
+county,office,district,party,candidate,votes
 CRAIG,State Senate,1,(D),CHARLES WYRICK,716
 CRAIG,State Senate,1,(R),PAT JURGENSMEYER,307
 DELAWARE,State Senate,1,(D),CHARLES WYRICK,"8,365"

--- a/2004/20041102__ok__general__us__senate__county.csv
+++ b/2004/20041102__ok__general__us__senate__county.csv
@@ -1,4 +1,4 @@
-County,Office,District,Party,Candidate,Votes
+county,office,district,party,candidate,votes
 ADAIR,U.S. Senate,,DEM,Brad Carson,"4,049"
 ADAIR,U.S. Senate,,REP,Tom Coburn,"3,160"
 ADAIR,U.S. Senate,,IND,Sheila Bilyeu,284

--- a/2004/20041102__ok__general__us_represenative__county.csv
+++ b/2004/20041102__ok__general__us_represenative__county.csv
@@ -1,4 +1,4 @@
-County,Office,District,Party,Candidate,Votes
+county,office,district,party,candidate,votes
 CREEK,U.S. House of Represenatives,1,(D),DOUG DODD,895
 CREEK,U.S. House of Represenatives,1,(R),JOHN SULLIVAN,"1,535"
 CREEK,U.S. House of Represenatives,1,(I),JOHN KRYMSKI,75


### PR DESCRIPTION
This modifies some column headers to be more consistent with other data files by making them lowercase and using more common names (e.g., `candidate` instead of `cand_name`).